### PR TITLE
feat: add api functionality to start/stop/status

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
 ## Features
 
 - **Request Forwarding:** Forwards all RPC requests to the specified target while logging the request and response details.
-- **Internal API:** Exposes an internal API for basic control of the proxy, such as temporarily stopping the forwarding of requests/responses.
+- **Flow Control API:** Start/stop proxy forwarding via REST API endpoints.
+- **WebSocket Module System:** Real-time module management for advanced monitoring and filtering.
+- **Metrics Integration:** Prometheus metrics endpoint for monitoring proxy performance.
 - **CLI Support:** Includes several command-line options for customizing the proxy's behavior.
 
 ## Installation
@@ -56,9 +58,165 @@ Options:
       --no-api                Do not provide management REST api
       --no-color              Do not use terminal colors in output
   -p, --port int              Port to listen for incoming requests. (default 3000)
+      --api-port int          Optional separate port for the snooper API endpoints
+      --api-auth string       Optional authentication for API endpoints (format: user:pass,user2:pass2,...)
+      --metrics-port int      Optional port for Prometheus metrics endpoint
   -v, --verbose               Run with verbose output
   -V, --version               Print version information
 ```
+
+## API Reference
+
+The snooper exposes several API endpoints under the `/_snooper/` prefix for controlling and monitoring the proxy.
+
+### Flow Control API
+
+Control the proxy forwarding behavior:
+
+#### GET `/_snooper/status`
+Get the current flow control status.
+
+**Response:**
+```json
+{
+  "status": "success",
+  "enabled": true,
+  "message": "Flow is enabled"
+}
+```
+
+#### POST `/_snooper/start`
+Enable proxy forwarding (allows requests to be forwarded to target).
+
+**Response:**
+```json
+{
+  "status": "success", 
+  "message": "Flow started",
+  "enabled": true
+}
+```
+
+#### POST `/_snooper/stop`
+Disable proxy forwarding (blocks requests with 503 Service Unavailable).
+
+**Response:**
+```json
+{
+  "status": "success",
+  "message": "Flow stopped", 
+  "enabled": false
+}
+```
+
+**Example Usage:**
+```bash
+# Check current status
+curl http://localhost:3000/_snooper/status
+
+# Stop forwarding requests
+curl -X POST http://localhost:3000/_snooper/stop
+
+# Resume forwarding requests  
+curl -X POST http://localhost:3000/_snooper/start
+```
+
+### WebSocket Module API
+
+Advanced real-time monitoring via WebSocket connection at `/_snooper/control`.
+
+**Supported Module Types:**
+- `request_snooper` - Monitor incoming requests
+- `response_snooper` - Monitor outgoing responses  
+- `request_counter` - Count and track requests
+- `response_tracer` - Trace response patterns
+
+**Module Registration:**
+```json
+{
+  "method": "register_module",
+  "data": {
+    "type": "request_snooper",
+    "name": "my-snooper",
+    "config": {
+      "request_filter": {
+        "methods": ["POST"],
+        "content_types": ["application/json"],
+        "json_query": "$.method"
+      }
+    }
+  }
+}
+```
+
+### Metrics API
+
+Prometheus metrics available at `/metrics` when metrics server is enabled:
+
+```bash
+# Start with metrics on port 9090
+./snooper --metrics-port 9090 http://localhost:8545
+
+# Access metrics
+curl http://localhost:9090/metrics
+```
+
+## Common Usage Scenarios
+
+### Basic Proxy with Flow Control
+```bash
+# Start the snooper proxy
+./snooper -p 3000 http://localhost:8545
+
+# Your RPC client connects to localhost:3000
+# All requests are forwarded to localhost:8545
+
+# Temporarily stop forwarding (useful for maintenance)
+curl -X POST http://localhost:3000/_snooper/stop
+
+# Resume forwarding
+curl -X POST http://localhost:3000/_snooper/start
+```
+
+### Authenticated API Access
+```bash
+# Start with API authentication
+./snooper --api-auth admin:secret123 --api-port 3001 http://localhost:8545
+
+# Access API with authentication
+curl -u admin:secret123 http://localhost:3001/_snooper/status
+curl -u admin:secret123 -X POST http://localhost:3001/_snooper/stop
+```
+
+### Monitoring and Metrics
+```bash
+# Start with separate API and metrics servers
+./snooper -p 3000 --api-port 3001 --metrics-port 9090 http://localhost:8545
+
+# Main proxy: localhost:3000
+# API endpoints: localhost:3001/_snooper/*  
+# Metrics: localhost:9090/metrics
+```
+
+### Error Responses
+
+When flow is disabled, all proxy requests return:
+```json
+{
+  "status": "error",
+  "message": "Proxy flow is currently disabled"
+}
+```
+**HTTP Status:** `503 Service Unavailable`
+
+### Authentication Required Response
+```json
+{
+  "status": "error", 
+  "message": "Unauthorized"
+}
+```
+**HTTP Status:** `401 Unauthorized`
 
 ## Contributing
 

--- a/snooper/api.go
+++ b/snooper/api.go
@@ -1,6 +1,7 @@
 package snooper
 
 import (
+	"encoding/json"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -18,5 +19,68 @@ func newAPI(snooper *Snooper) *API {
 
 func (api *API) initRouter(router *mux.Router) {
 	router.HandleFunc("/control", api.snooper.moduleManager.HandleWebSocket)
+	router.HandleFunc("/start", api.handleStart).Methods("POST")
+	router.HandleFunc("/stop", api.handleStop).Methods("POST")
+	router.HandleFunc("/status", api.handleStatus).Methods("GET")
 	router.PathPrefix("/").Handler(http.DefaultServeMux)
+}
+
+func (api *API) handleStart(w http.ResponseWriter, r *http.Request) {
+	api.snooper.flowMutex.Lock()
+	api.snooper.flowEnabled = true
+	api.snooper.flowMutex.Unlock()
+
+	api.snooper.logger.Info("Flow started - proxy requests enabled")
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	
+	response := map[string]interface{}{
+		"status":  "success",
+		"message": "Flow started",
+		"enabled": true,
+	}
+	
+	json.NewEncoder(w).Encode(response)
+}
+
+func (api *API) handleStop(w http.ResponseWriter, r *http.Request) {
+	api.snooper.flowMutex.Lock()
+	api.snooper.flowEnabled = false
+	api.snooper.flowMutex.Unlock()
+
+	api.snooper.logger.Info("Flow stopped - proxy requests disabled")
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	
+	response := map[string]interface{}{
+		"status":  "success",
+		"message": "Flow stopped",
+		"enabled": false,
+	}
+	
+	json.NewEncoder(w).Encode(response)
+}
+
+func (api *API) handleStatus(w http.ResponseWriter, r *http.Request) {
+	api.snooper.flowMutex.RLock()
+	enabled := api.snooper.flowEnabled
+	api.snooper.flowMutex.RUnlock()
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	
+	response := map[string]interface{}{
+		"status":  "success",
+		"enabled": enabled,
+		"message": func() string {
+			if enabled {
+				return "Flow is enabled"
+			}
+			return "Flow is disabled"
+		}(),
+	}
+	
+	json.NewEncoder(w).Encode(response)
 }

--- a/snooper/api.go
+++ b/snooper/api.go
@@ -34,13 +34,13 @@ func (api *API) handleStart(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	
+
 	response := map[string]interface{}{
 		"status":  "success",
 		"message": "Flow started",
 		"enabled": true,
 	}
-	
+
 	json.NewEncoder(w).Encode(response)
 }
 
@@ -53,13 +53,13 @@ func (api *API) handleStop(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	
+
 	response := map[string]interface{}{
 		"status":  "success",
 		"message": "Flow stopped",
 		"enabled": false,
 	}
-	
+
 	json.NewEncoder(w).Encode(response)
 }
 
@@ -70,7 +70,7 @@ func (api *API) handleStatus(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	
+
 	response := map[string]interface{}{
 		"status":  "success",
 		"enabled": enabled,
@@ -81,6 +81,6 @@ func (api *API) handleStatus(w http.ResponseWriter, r *http.Request) {
 			return "Flow is disabled"
 		}(),
 	}
-	
+
 	json.NewEncoder(w).Encode(response)
 }

--- a/snooper/api.go
+++ b/snooper/api.go
@@ -25,7 +25,7 @@ func (api *API) initRouter(router *mux.Router) {
 	router.PathPrefix("/").Handler(http.DefaultServeMux)
 }
 
-func (api *API) handleStart(w http.ResponseWriter, r *http.Request) {
+func (api *API) handleStart(w http.ResponseWriter, _ *http.Request) {
 	api.snooper.flowMutex.Lock()
 	api.snooper.flowEnabled = true
 	api.snooper.flowMutex.Unlock()
@@ -41,10 +41,12 @@ func (api *API) handleStart(w http.ResponseWriter, r *http.Request) {
 		"enabled": true,
 	}
 
-	json.NewEncoder(w).Encode(response)
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		api.snooper.logger.Errorf("failed writing start response: %v", err)
+	}
 }
 
-func (api *API) handleStop(w http.ResponseWriter, r *http.Request) {
+func (api *API) handleStop(w http.ResponseWriter, _ *http.Request) {
 	api.snooper.flowMutex.Lock()
 	api.snooper.flowEnabled = false
 	api.snooper.flowMutex.Unlock()
@@ -60,10 +62,12 @@ func (api *API) handleStop(w http.ResponseWriter, r *http.Request) {
 		"enabled": false,
 	}
 
-	json.NewEncoder(w).Encode(response)
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		api.snooper.logger.Errorf("failed writing stop response: %v", err)
+	}
 }
 
-func (api *API) handleStatus(w http.ResponseWriter, r *http.Request) {
+func (api *API) handleStatus(w http.ResponseWriter, _ *http.Request) {
 	api.snooper.flowMutex.RLock()
 	enabled := api.snooper.flowEnabled
 	api.snooper.flowMutex.RUnlock()
@@ -82,5 +86,7 @@ func (api *API) handleStatus(w http.ResponseWriter, r *http.Request) {
 		}(),
 	}
 
-	json.NewEncoder(w).Encode(response)
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		api.snooper.logger.Errorf("failed writing status response: %v", err)
+	}
 }

--- a/snooper/proxycall.go
+++ b/snooper/proxycall.go
@@ -92,12 +92,12 @@ func (s *Snooper) processProxyCall(w http.ResponseWriter, r *http.Request) error
 	if !flowEnabled {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusServiceUnavailable)
-		
+
 		response := map[string]interface{}{
 			"status":  "error",
 			"message": "Proxy flow is currently disabled",
 		}
-		
+
 		if err := json.NewEncoder(w).Encode(response); err != nil {
 			s.logger.Errorf("failed writing flow disabled response: %v", err)
 		}

--- a/snooper/proxycall.go
+++ b/snooper/proxycall.go
@@ -101,6 +101,7 @@ func (s *Snooper) processProxyCall(w http.ResponseWriter, r *http.Request) error
 		if err := json.NewEncoder(w).Encode(response); err != nil {
 			s.logger.Errorf("failed writing flow disabled response: %v", err)
 		}
+
 		return nil
 	}
 

--- a/snooper/snooper.go
+++ b/snooper/snooper.go
@@ -36,6 +36,10 @@ type Snooper struct {
 	callIndexMutex   sync.Mutex
 
 	orderedProcessor *OrderedProcessor
+
+	// Flow control
+	flowEnabled bool
+	flowMutex   sync.RWMutex
 }
 
 func NewSnooper(target string, logger logrus.FieldLogger) (*Snooper, error) {
@@ -50,6 +54,7 @@ func NewSnooper(target string, logger logrus.FieldLogger) (*Snooper, error) {
 		target:        targetURL,
 		logger:        logger,
 		moduleManager: modules.NewManager(logger),
+		flowEnabled:   true, // Start with flow enabled by default
 	}
 
 	snooper.orderedProcessor = NewOrderedProcessor(snooper)


### PR DESCRIPTION
stopping:
```
curl -v -X POST http://localhost:40563/_snooper/stop

{"enabled":false,"message":"Flow stopped","status":"success"}
```

starting:
```
curl -v -X POST http://localhost:40563/_snooper/start

{"enabled":true,"message":"Flow started","status":"success"}
```

status:
```
curl -v -X GET http://localhost:40563/_snooper/status

{"enabled":true,"message":"Flow is enabled","status":"success"}
```