### PR TITLE
Add --delay-payload flag to inject latency on engine_newPayload calls

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -65,55 +65,106 @@ jobs:
         echo "build_docker=$build_docker" >> $GITHUB_OUTPUT
         echo "docker_tag=$branch_name" >> $GITHUB_OUTPUT
 
-  build_docker:
-    name: "Build snooper docker image"
+  build_amd64_docker_image:
+    name: "Build amd64 docker image"
     needs: [prinfo]
-    if: ${{ needs.prinfo.outputs.run_builds == 'true' }}
+    if: ${{ needs.prinfo.outputs.build_docker == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        fetch-depth: 0
 
     - name: Get build version
       id: vars
       run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
-    # prepare docker
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-
-    # only same-repository PRs get docker credentials, forked PRs build without pushing
     - name: Login to Docker Hub
-      if: ${{ needs.prinfo.outputs.build_docker == 'true' }}
       uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-    # build (and push when allowed) a multiarch image tagged with the branch name
-    - name: Build docker image
+    - name: Build and push amd64 docker image
       env:
         DOCKER_REPO: "ethpandaops/rpc-snooper"
         DOCKER_TAG: ${{ needs.prinfo.outputs.docker_tag }}
         SHA_SHORT: ${{ steps.vars.outputs.sha_short }}
-        BUILD_DOCKER: ${{ needs.prinfo.outputs.build_docker }}
       run: |
-        push_flag=""
-        if [[ "$BUILD_DOCKER" == "true" ]]; then
-          push_flag="--push"
-        else
-          echo "Forked PR: building image for validation only, not pushing."
-        fi
-
         docker buildx build . \
           --file Dockerfile \
-          --platform linux/amd64,linux/arm64 \
-          --tag "${DOCKER_REPO}:${DOCKER_TAG}" \
-          --tag "${DOCKER_REPO}:${DOCKER_TAG}-latest" \
-          --tag "${DOCKER_REPO}:${DOCKER_TAG}-${SHA_SHORT}" \
-          $push_flag
+          --platform linux/amd64 \
+          --tag "${DOCKER_REPO}:${DOCKER_TAG}-${SHA_SHORT}-amd64" \
+          --push
+
+  build_arm64_docker_image:
+    name: "Build arm64 docker image"
+    needs: [prinfo]
+    if: ${{ needs.prinfo.outputs.build_docker == 'true' }}
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+    - name: Get build version
+      id: vars
+      run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+    - name: Login to Docker Hub
+      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    - name: Build and push arm64 docker image
+      env:
+        DOCKER_REPO: "ethpandaops/rpc-snooper"
+        DOCKER_TAG: ${{ needs.prinfo.outputs.docker_tag }}
+        SHA_SHORT: ${{ steps.vars.outputs.sha_short }}
+      run: |
+        docker buildx build . \
+          --file Dockerfile \
+          --platform linux/arm64 \
+          --tag "${DOCKER_REPO}:${DOCKER_TAG}-${SHA_SHORT}-arm64" \
+          --push
+
+  build_multiarch_image:
+    name: "Build multiarch docker manifest"
+    needs: [prinfo, build_amd64_docker_image, build_arm64_docker_image]
+    if: ${{ needs.prinfo.outputs.build_docker == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+    - name: Get build version
+      id: vars
+      run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+    - name: Login to Docker Hub
+      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    # combine the natively-built per-arch images into the branch-named multiarch tags
+    - name: Create multiarch manifests
+      env:
+        DOCKER_REPO: "ethpandaops/rpc-snooper"
+        DOCKER_TAG: ${{ needs.prinfo.outputs.docker_tag }}
+        SHA_SHORT: ${{ steps.vars.outputs.sha_short }}
+      run: |
+        docker buildx imagetools create \
+          -t "${DOCKER_REPO}:${DOCKER_TAG}" \
+          -t "${DOCKER_REPO}:${DOCKER_TAG}-latest" \
+          -t "${DOCKER_REPO}:${DOCKER_TAG}-${SHA_SHORT}" \
+          "${DOCKER_REPO}:${DOCKER_TAG}-${SHA_SHORT}-amd64" \
+          "${DOCKER_REPO}:${DOCKER_TAG}-${SHA_SHORT}-arm64"

--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -80,9 +80,9 @@ jobs:
       run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
     - name: Login to Docker Hub
-      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -114,9 +114,9 @@ jobs:
       run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
     - name: Login to Docker Hub
-      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -148,9 +148,9 @@ jobs:
       run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
     - name: Login to Docker Hub
-      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Options:
       --api-bind string       Address to bind for API endpoints (default "0.0.0.0")
       --api-port int          Optional separate port for API endpoints
       --api-auth string       Authentication for API endpoints (format: user:pass,user2:pass2,...)
-      --delay-payload int     Inject latency (in milliseconds) on engine_newPayload calls, split evenly across the request and response paths
+      --delay-payload int     Inject latency (in milliseconds) on engine_newPayload calls, split evenly across the request and response paths (default 0)
       --metrics-bind string   Address to bind for metrics endpoint (default "127.0.0.1")
       --metrics-port int      Port for Prometheus metrics endpoint
       --no-api                Disable management REST API

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Options:
       --api-bind string       Address to bind for API endpoints (default "0.0.0.0")
       --api-port int          Optional separate port for API endpoints
       --api-auth string       Authentication for API endpoints (format: user:pass,user2:pass2,...)
+      --delay-payload int     Inject latency (in milliseconds) on engine_newPayload calls, split evenly across the request and response paths
       --metrics-bind string   Address to bind for metrics endpoint (default "127.0.0.1")
       --metrics-port int      Port for Prometheus metrics endpoint
       --no-api                Disable management REST API

--- a/cmd/snooper/main.go
+++ b/cmd/snooper/main.go
@@ -51,6 +51,9 @@ type CliArgs struct {
 	// Hide request/response bodies
 	hideBodies bool
 
+	// Inject latency (milliseconds) on engine_newPayload calls
+	delayPayload int
+
 	// Engine API authentication
 	jwtSecret string
 }
@@ -173,21 +176,22 @@ func buildXatuConfig(args *CliArgs) (*xatu.Config, error) {
 func main() {
 	// Load defaults from environment variables
 	cliArgs := CliArgs{
-		verbose:     getEnvBool("SNOOPER_VERBOSE", false),
-		version:     getEnvBool("SNOOPER_VERSION", false),
-		help:        getEnvBool("SNOOPER_HELP", false),
-		bind:        getEnvString("SNOOPER_BIND_ADDRESS", "127.0.0.1"),
-		port:        getEnvInt("SNOOPER_PORT", 3000),
-		nocolor:     getEnvBool("SNOOPER_NO_COLOR", false),
-		truncate:    getEnvBool("SNOOPER_TRUNCATE", true),
-		noapi:       getEnvBool("SNOOPER_NO_API", false),
-		apiPort:     getEnvInt("SNOOPER_API_PORT", 0),
-		apiBind:     getEnvString("SNOOPER_API_BIND", "0.0.0.0"),
-		apiAuth:     getEnvString("SNOOPER_API_AUTH", ""),
-		metricsPort: getEnvInt("SNOOPER_METRICS_PORT", 0),
-		metricsBind: getEnvString("SNOOPER_METRICS_BIND", "127.0.0.1"),
-		jwtSecret:   getEnvString("SNOOPER_JWT_SECRET", ""),
-		hideBodies:  getEnvBool("SNOOPER_HIDE_BODIES", false),
+		verbose:      getEnvBool("SNOOPER_VERBOSE", false),
+		version:      getEnvBool("SNOOPER_VERSION", false),
+		help:         getEnvBool("SNOOPER_HELP", false),
+		bind:         getEnvString("SNOOPER_BIND_ADDRESS", "127.0.0.1"),
+		port:         getEnvInt("SNOOPER_PORT", 3000),
+		nocolor:      getEnvBool("SNOOPER_NO_COLOR", false),
+		truncate:     getEnvBool("SNOOPER_TRUNCATE", true),
+		noapi:        getEnvBool("SNOOPER_NO_API", false),
+		apiPort:      getEnvInt("SNOOPER_API_PORT", 0),
+		apiBind:      getEnvString("SNOOPER_API_BIND", "0.0.0.0"),
+		apiAuth:      getEnvString("SNOOPER_API_AUTH", ""),
+		metricsPort:  getEnvInt("SNOOPER_METRICS_PORT", 0),
+		metricsBind:  getEnvString("SNOOPER_METRICS_BIND", "127.0.0.1"),
+		jwtSecret:    getEnvString("SNOOPER_JWT_SECRET", ""),
+		hideBodies:   getEnvBool("SNOOPER_HIDE_BODIES", false),
+		delayPayload: getEnvInt("SNOOPER_DELAY_PAYLOAD", 0),
 
 		// Xatu defaults from environment
 		xatuEnabled:            getEnvBool("SNOOPER_XATU_ENABLED", false),
@@ -224,6 +228,7 @@ func main() {
 	flags.StringVar(&cliArgs.metricsBind, "metrics-bind", cliArgs.metricsBind, "Optional address to bind to for the Prometheus metrics endpoint (env: SNOOPER_METRICS_BIND)")
 	flags.StringVar(&cliArgs.jwtSecret, "jwt-secret", cliArgs.jwtSecret, "JWT secret for Engine API authentication - file path or hex-encoded value (env: SNOOPER_JWT_SECRET)")
 	flags.BoolVar(&cliArgs.hideBodies, "hide-bodies", cliArgs.hideBodies, "Hide request/response bodies in log output, showing only method, headers, status and timing (env: SNOOPER_HIDE_BODIES)")
+	flags.IntVar(&cliArgs.delayPayload, "delay-payload", cliArgs.delayPayload, "Inject latency (in milliseconds) on engine_newPayload calls, split evenly across the request and response paths (env: SNOOPER_DELAY_PAYLOAD)")
 
 	// Xatu flags
 	flags.BoolVar(&cliArgs.xatuEnabled, "xatu-enabled", cliArgs.xatuEnabled, "Enable Xatu event publishing (env: SNOOPER_XATU_ENABLED)")
@@ -309,6 +314,10 @@ func main() {
 
 	if cliArgs.hideBodies {
 		rpcSnooper.EnableHideBodies()
+	}
+
+	if cliArgs.delayPayload > 0 {
+		rpcSnooper.SetPayloadDelay(time.Duration(cliArgs.delayPayload) * time.Millisecond)
 	}
 
 	// Start separate API server if api-port is specified

--- a/snooper/proxycall.go
+++ b/snooper/proxycall.go
@@ -2,6 +2,7 @@ package snooper
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -155,8 +156,26 @@ func (s *Snooper) processProxyCall(w http.ResponseWriter, r *http.Request) error
 		return fmt.Errorf("error parsing proxy url: %w", err)
 	}
 
+	// When payload delay is configured we must inspect the JSON-RPC method
+	// (which lives in the request body) before forwarding, so buffer the body
+	// and replace it with an in-memory reader.
+	reqBody := r.Body
+	delayNewPayload := false
+
+	if s.payloadDelay > 0 {
+		bodyBytes, err := io.ReadAll(r.Body)
+		if err != nil {
+			return fmt.Errorf("error reading request body: %w", err)
+		}
+
+		r.Body.Close()
+
+		delayNewPayload = s.isEngineNewPayloadRequest(bodyBytes, r.Header.Get("Content-Encoding"))
+		reqBody = io.NopCloser(bytes.NewReader(bodyBytes))
+	}
+
 	// Create body reader with module processing and logging
-	bodyReader := s.createRequestProcessingStream(callContext, r, r.Body)
+	bodyReader := s.createRequestProcessingStream(callContext, r, reqBody)
 	defer bodyReader.Close()
 
 	// construct request to send to origin server
@@ -171,6 +190,16 @@ func (s *Snooper) processProxyCall(w http.ResponseWriter, r *http.Request) error
 	client := &http.Client{Timeout: 0}
 	req = req.WithContext(callContext.context)
 
+	// Split the configured payload delay evenly across the request and
+	// response paths. reqDelay gets the floor so the two halves still sum to
+	// the configured value for odd millisecond counts.
+	reqDelay := s.payloadDelay / 2
+	respDelay := s.payloadDelay - reqDelay
+
+	if delayNewPayload {
+		s.delayPayloadCall(callContext, reqDelay)
+	}
+
 	callStart := time.Now()
 	resp, err := client.Do(req)
 
@@ -181,6 +210,10 @@ func (s *Snooper) processProxyCall(w http.ResponseWriter, r *http.Request) error
 	if callContext.cancelled {
 		resp.Body.Close()
 		return fmt.Errorf("proxy context cancelled")
+	}
+
+	if delayNewPayload {
+		s.delayPayloadCall(callContext, respDelay)
 	}
 
 	callContext.streamReader = resp.Body
@@ -243,6 +276,62 @@ func (s *Snooper) processProxyCall(w http.ResponseWriter, r *http.Request) error
 	}
 
 	return nil
+}
+
+// delayPayloadCall sleeps for the given duration to inject artificial latency
+// on a proxied call. The call deadline is pushed out first so the timeout
+// watchdog does not fire during the delay, and the sleep aborts early if the
+// call context is cancelled (e.g. the client disconnects).
+func (s *Snooper) delayPayloadCall(callCtx *ProxyCallContext, d time.Duration) {
+	if d <= 0 {
+		return
+	}
+
+	select {
+	case callCtx.updateChan <- s.CallTimeout + d:
+	default:
+	}
+
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+
+	select {
+	case <-callCtx.context.Done():
+	case <-timer.C:
+	}
+}
+
+// isEngineNewPayloadRequest reports whether the JSON-RPC request body is an
+// engine_newPayloadV* call. The body is decompressed if necessary. Anything
+// that fails to parse as a JSON-RPC request is treated as "not newPayload".
+func (s *Snooper) isEngineNewPayloadRequest(body []byte, contentEncoding string) bool {
+	decoded, err := s.decompressBody(body, contentEncoding)
+	if err != nil {
+		return false
+	}
+
+	var parsed any
+	if err := json.Unmarshal(decoded, &parsed); err != nil {
+		return false
+	}
+
+	switch v := parsed.(type) {
+	case map[string]any:
+		return isNewPayloadMethod(v)
+	case []any:
+		for _, item := range v {
+			if obj, ok := item.(map[string]any); ok && isNewPayloadMethod(obj) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func isNewPayloadMethod(obj map[string]any) bool {
+	method, ok := obj["method"].(string)
+	return ok && strings.HasPrefix(method, "engine_newPayload")
 }
 
 func (s *Snooper) processEventStreamResponse(callContext *ProxyCallContext, r *http.Request, w http.ResponseWriter, rsp *http.Response) (int64, error) {

--- a/snooper/snooper.go
+++ b/snooper/snooper.go
@@ -46,6 +46,9 @@ type Snooper struct {
 	// Hide request/response bodies
 	hideBodies bool
 
+	// Artificial latency injected on engine_newPayload calls
+	payloadDelay time.Duration
+
 	// Flow control
 	flowEnabled bool
 	flowBlocked map[string]bool
@@ -118,6 +121,13 @@ func (s *Snooper) EnableLogTruncation() {
 // Call this once at startup before serving requests.
 func (s *Snooper) EnableHideBodies() {
 	s.hideBodies = true
+}
+
+// SetPayloadDelay configures an artificial latency injected on
+// engine_newPayload calls, split evenly across the request and response
+// paths. Call this once at startup before serving requests.
+func (s *Snooper) SetPayloadDelay(d time.Duration) {
+	s.payloadDelay = d
 }
 
 func (s *Snooper) Shutdown() {


### PR DESCRIPTION
## Summary
- Adds a `--delay-payload` flag (milliseconds, env `SNOOPER_DELAY_PAYLOAD`, default `0` = disabled) that injects artificial latency on `engine_newPayloadV*` calls only.
- The delay is split evenly across the request path (CL→EL) and the response path (EL→CL), simulating slow payload delivery for devnet/client testing.
- Because the JSON-RPC method lives in the POST body (not the URL), the request body is buffered and parsed to detect `engine_newPayload*` (covers V1–V4+, including batch requests) — only when the flag is enabled, so normal usage is unaffected.

## Implementation notes
- `cmd/snooper/main.go`: new `delayPayload` CLI arg + env default, `--delay-payload` flag, and `SetPayloadDelay(...)` wiring.
- `snooper/snooper.go`: `payloadDelay` field + `SetPayloadDelay` setter.
- `snooper/proxycall.go`: conditional body buffering, `engine_newPayload` detection, and a context-aware sleep that extends the call deadline (so the timeout watchdog doesn't fire) and aborts early on client disconnect.
- The response-side half is reflected in the logged `duration_ms`; the request-side half is pre-flight and is not.

## Test plan
- [ ] `gofmt`, `go vet ./...`, `go test ./...` pass (verified locally via `golang:1.25` container).
- [ ] With `--delay-payload 250 <target>`, confirm `engine_newPayload*` calls take ~250ms longer (125ms each side) while other methods are unaffected.
- [ ] Confirm `--delay-payload 0` / unset leaves behavior and body streaming unchanged.