### PR TITLE
Cap decompressed request and response body size

### DIFF
--- a/snooper/decompress_test.go
+++ b/snooper/decompress_test.go
@@ -1,0 +1,136 @@
+package snooper
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"testing"
+
+	"github.com/andybalholm/brotli"
+	"github.com/sirupsen/logrus"
+)
+
+func quietTestSnooper() *Snooper {
+	lg := logrus.New()
+	lg.SetOutput(io.Discard)
+
+	return &Snooper{logger: lg}
+}
+
+// gzipOfZeros returns a gzip stream that inflates to n zero bytes without
+// holding the plaintext in memory while building it.
+func gzipOfZeros(n int64) []byte {
+	var buf bytes.Buffer
+
+	zw, _ := gzip.NewWriterLevel(&buf, gzip.BestCompression)
+	chunk := make([]byte, 1<<20)
+
+	for written := int64(0); written < n; {
+		size := int64(len(chunk))
+		if n-written < size {
+			size = n - written
+		}
+
+		_, _ = zw.Write(chunk[:size])
+		written += size
+	}
+
+	_ = zw.Close()
+
+	return buf.Bytes()
+}
+
+func brotliOfZeros(n int64) []byte {
+	var buf bytes.Buffer
+
+	bw := brotli.NewWriterLevel(&buf, brotli.BestCompression)
+	chunk := make([]byte, 1<<20)
+
+	for written := int64(0); written < n; {
+		size := int64(len(chunk))
+		if n-written < size {
+			size = n - written
+		}
+
+		_, _ = bw.Write(chunk[:size])
+		written += size
+	}
+
+	_ = bw.Close()
+
+	return buf.Bytes()
+}
+
+// A body that decompresses beyond the cap must be rejected with an error and no
+// returned payload, rather than inflating without bound.
+func TestDecompressBodyRejectsOversized(t *testing.T) {
+	s := quietTestSnooper()
+
+	for _, enc := range []string{"gzip", "br"} {
+		var bomb []byte
+		if enc == "gzip" {
+			bomb = gzipOfZeros(maxDecompressedBodySize + (8 << 20))
+		} else {
+			bomb = brotliOfZeros(maxDecompressedBodySize + (8 << 20))
+		}
+
+		out, err := s.decompressBody(bomb, enc)
+		if err == nil {
+			t.Fatalf("%s: expected an error for an oversized body, got nil", enc)
+		}
+
+		if len(out) != 0 {
+			t.Fatalf("%s: expected no payload on overflow, got %d bytes", enc, len(out))
+		}
+	}
+}
+
+// A normal-sized body must decompress correctly, and unknown encodings must pass
+// through unchanged.
+func TestDecompressBodyAllowsNormal(t *testing.T) {
+	s := quietTestSnooper()
+	payload := []byte(`{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}`)
+
+	var gzipped bytes.Buffer
+
+	zw := gzip.NewWriter(&gzipped)
+	if _, err := zw.Write(payload); err != nil {
+		t.Fatalf("gzip write: %v", err)
+	}
+
+	if err := zw.Close(); err != nil {
+		t.Fatalf("gzip close: %v", err)
+	}
+
+	out, err := s.decompressBody(gzipped.Bytes(), "gzip")
+	if err != nil {
+		t.Fatalf("gzip: unexpected error: %v", err)
+	}
+
+	if !bytes.Equal(out, payload) {
+		t.Fatalf("gzip: roundtrip mismatch")
+	}
+
+	out, err = s.decompressBody(payload, "")
+	if err != nil {
+		t.Fatalf("passthrough: unexpected error: %v", err)
+	}
+
+	if !bytes.Equal(out, payload) {
+		t.Fatalf("passthrough: body changed")
+	}
+}
+
+// A body sitting exactly at the cap must still be accepted.
+func TestDecompressBodyAllowsAtLimit(t *testing.T) {
+	s := quietTestSnooper()
+
+	out, err := s.decompressBody(gzipOfZeros(maxDecompressedBodySize), "gzip")
+	if err != nil {
+		t.Fatalf("body at the limit should be accepted, got: %v", err)
+	}
+
+	if int64(len(out)) != maxDecompressedBodySize {
+		t.Fatalf("expected %d bytes at the limit, got %d", int64(maxDecompressedBodySize), len(out))
+	}
+}

--- a/snooper/logging.go
+++ b/snooper/logging.go
@@ -250,6 +250,13 @@ func (s *Snooper) logRequest(ctx *ProxyCallContext, req *http.Request, bodyBytes
 	s.logger.WithFields(logFields).Infof("REQUEST #%v: %v %v", ctx.callIndex, req.Method, req.URL.String())
 }
 
+// maxDecompressedBodySize caps how many bytes decompressBody will materialize
+// from a compressed body. Without a cap, a small gzip or brotli payload can
+// inflate to gigabytes and exhaust memory, which is fatal because the proxy
+// sits inline on the request path. Bodies that decompress beyond this are not
+// logged. The limit is generous enough for real Engine API payloads.
+const maxDecompressedBodySize = 64 << 20 // 64 MiB
+
 func (s *Snooper) decompressBody(data []byte, contentEncoding string) ([]byte, error) {
 	switch contentEncoding {
 	case "gzip":
@@ -260,16 +267,28 @@ func (s *Snooper) decompressBody(data []byte, contentEncoding string) ([]byte, e
 		}
 		defer gzipReader.Close()
 
-		decompressed, _ := io.ReadAll(gzipReader)
-
-		return decompressed, nil
+		return readCapped(gzipReader)
 	case "br":
-		decompressed, _ := io.ReadAll(brotli.NewReader(bytes.NewReader(data)))
-
-		return decompressed, nil
+		return readCapped(brotli.NewReader(bytes.NewReader(data)))
 	default:
 		return data, nil
 	}
+}
+
+// readCapped reads up to maxDecompressedBodySize bytes from r. If the stream
+// produces more than that, it returns an error instead of allocating without
+// bound, which stops decompression bombs from exhausting memory.
+func readCapped(r io.Reader) ([]byte, error) {
+	out, err := io.ReadAll(io.LimitReader(r, maxDecompressedBodySize+1))
+	if err != nil {
+		return nil, err
+	}
+
+	if int64(len(out)) > maxDecompressedBodySize {
+		return nil, fmt.Errorf("decompressed body exceeds %d byte limit", maxDecompressedBodySize)
+	}
+
+	return out, nil
 }
 
 func (s *Snooper) logResponse(ctx *ProxyCallContext, req *http.Request, rsp *http.Response, bodyBytes []byte) {


### PR DESCRIPTION
Decompressing a proxied gzip or brotli body used io.ReadAll with no upper bound, so a small compressed payload could inflate to gigabytes and exhaust memory. Because the proxy sits inline on the request path, that crash also stalls the node behind it.

A ~300 KiB gzip body inflates to ~300 MiB, and an under 1 KiB brotli body inflates past 500 MiB, on either the request path (Content-Encoding on the request) or the response path.

This bounds decompression to 64 MiB and returns an error when a body exceeds it, leaving oversized bodies unlogged rather than crashing the process. The limit is generous enough for real Engine API payloads.

Tests cover the oversized (gzip and brotli), normal, passthrough, and at-limit cases.