### PR TITLE
Bound metrics label cardinality

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -5,11 +5,56 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/ethpandaops/rpc-snooper/types"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+// maxDistinctLabelValues bounds how many distinct values each caller-influenced
+// label (uri, jrpc_method) may contribute. Prometheus retains one child series
+// per unique label tuple for the lifetime of the process, so without a bound a
+// caller varying the request path or JSON-RPC method would grow memory without
+// limit. Values seen after the bound is reached are recorded as overflowLabel.
+const maxDistinctLabelValues = 128
+
+const overflowLabel = "other"
+
+// boundedLabelSet tracks the distinct values used for a single label and caps
+// them at maxDistinctLabelValues.
+type boundedLabelSet struct {
+	mu   sync.Mutex
+	seen map[string]struct{}
+}
+
+func newBoundedLabelSet() *boundedLabelSet {
+	return &boundedLabelSet{seen: make(map[string]struct{})}
+}
+
+// value returns v when it is already known or there is still room under the
+// bound, otherwise the overflow placeholder.
+func (b *boundedLabelSet) value(v string) string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if _, ok := b.seen[v]; ok {
+		return v
+	}
+
+	if len(b.seen) >= maxDistinctLabelValues {
+		return overflowLabel
+	}
+
+	b.seen[v] = struct{}{}
+
+	return v
+}
+
+var (
+	uriLabels        = newBoundedLabelSet()
+	jrpcMethodLabels = newBoundedLabelSet()
 )
 
 type MetricsEntry struct { //nolint:revive // ignore
@@ -73,8 +118,8 @@ func PrometheusMetricsRegister(l *MetricsEntry) {
 		l.Method,
 		l.Hostname,
 		l.Status,
-		l.URI,
-		l.JRPCMethod,
+		uriLabels.value(l.URI),
+		jrpcMethodLabels.value(l.JRPCMethod),
 	}
 
 	requestCounter.WithLabelValues(tags...).Inc()
@@ -108,11 +153,9 @@ func CreateMetricsEntryFromContexts(target *url.URL, reqCtx *types.RequestContex
 	if reqCtx != nil {
 		entry.Method = reqCtx.Method
 		entry.Hostname = reqCtx.URL.Host
+		// The raw query string carries no metrics value and is fully
+		// caller-controlled, so it is excluded from the uri label.
 		entry.URI = reqCtx.URL.Path
-
-		if reqCtx.URL.RawQuery != "" {
-			entry.URI += "?" + reqCtx.URL.RawQuery
-		}
 
 		entry.BytesReceived = int64(len(reqCtx.BodyBytes))
 	}

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -1,0 +1,96 @@
+package metrics
+
+import (
+	"fmt"
+	"net/url"
+	"testing"
+
+	"github.com/ethpandaops/rpc-snooper/types"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// The bounded set must pass known values and values under the cap, and collapse
+// everything beyond the cap to the overflow placeholder.
+func TestBoundedLabelSetCapsDistinctValues(t *testing.T) {
+	set := newBoundedLabelSet()
+
+	for i := 0; i < maxDistinctLabelValues; i++ {
+		v := fmt.Sprintf("v%d", i)
+		if got := set.value(v); got != v {
+			t.Fatalf("value %q under the cap returned %q", v, got)
+		}
+	}
+
+	// A new value beyond the cap overflows.
+	if got := set.value("overflow-me"); got != overflowLabel {
+		t.Fatalf("expected %q past the cap, got %q", overflowLabel, got)
+	}
+
+	// An already-seen value still passes after the cap is reached.
+	if got := set.value("v0"); got != "v0" {
+		t.Fatalf("known value should still pass, got %q", got)
+	}
+}
+
+// distinctURIValues counts how many distinct uri label values exist across the
+// request vectors in the default registry.
+func distinctURIValues(t *testing.T) int {
+	t.Helper()
+
+	fams, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+
+	seen := map[string]struct{}{}
+
+	for _, f := range fams {
+		if f.GetName() != "ngx_request_count" {
+			continue
+		}
+
+		for _, m := range f.GetMetric() {
+			for _, lp := range m.GetLabel() {
+				if lp.GetName() == "uri" {
+					seen[lp.GetValue()] = struct{}{}
+				}
+			}
+		}
+	}
+
+	return len(seen)
+}
+
+// Registering far more unique URIs than the cap must not create an unbounded
+// number of uri label values: the total distinct values stays within the bound.
+func TestPrometheusMetricsRegisterBoundsURICardinality(t *testing.T) {
+	for i := 0; i < 5000; i++ {
+		PrometheusMetricsRegister(&MetricsEntry{
+			Server: "t", Scheme: "http", Method: "POST", Hostname: "h", Status: "200",
+			URI:        fmt.Sprintf("/path-%d", i),
+			JRPCMethod: "eth_call",
+		})
+	}
+
+	distinct := distinctURIValues(t)
+	t.Logf("registered 5000 unique URIs; distinct uri label values retained: %d (cap %d + overflow)", distinct, maxDistinctLabelValues)
+
+	if distinct > maxDistinctLabelValues+1 {
+		t.Fatalf("uri cardinality unbounded: %d distinct values exceed cap %d+1", distinct, maxDistinctLabelValues)
+	}
+}
+
+// The uri label must not include the raw query string.
+func TestCreateMetricsEntryDropsQueryString(t *testing.T) {
+	target, _ := url.Parse("http://upstream:8551")
+	reqURL, _ := url.Parse("http://proxy/some/path?evil=1&more=2")
+
+	entry := CreateMetricsEntryFromContexts(target, &types.RequestContext{
+		Method: "POST",
+		URL:    reqURL,
+	}, nil)
+
+	if entry.URI != "/some/path" {
+		t.Fatalf("expected uri without query string, got %q", entry.URI)
+	}
+}


### PR DESCRIPTION
The uri and jrpc_method Prometheus labels were taken verbatim from the request path, query string, and JSON-RPC method, all caller-controlled. Prometheus retains one child series per unique label tuple for the life of the process, so a caller varying the query string or method could grow memory without bound and exhaust the host.

Measured on the current code: 100,000 unique request URIs retain about 500 MiB of live heap that survives garbage collection, roughly 5 KiB per distinct value, and it never drops. Normal Engine API traffic is low cardinality, so this only grows under abusive input.

This caps the distinct values for each of those two labels at 128 and records further values as "other", and drops the raw query string from the uri label since it carries no metrics value. After the change the same 100,000 unique URIs retain well under 1 MiB. Normal traffic stays within the cap.

Tests cover the cap behavior, the overall cardinality bound, and query-string removal.