### PR TITLE
Serialize request-body tee reads and close

### DIFF
--- a/snooper/logging.go
+++ b/snooper/logging.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"runtime/debug"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/andybalholm/brotli"
@@ -89,6 +90,7 @@ func (s *Snooper) formatHexBodyForLog(bodyData []byte) string {
 }
 
 type logReadCloser struct {
+	mu       sync.Mutex
 	reader   io.Reader
 	buf      *bytes.Buffer
 	original io.ReadCloser
@@ -123,12 +125,26 @@ func (s *Snooper) createTeeLogStreamWithSizeHint(stream io.ReadCloser, sizeHint 
 	}
 }
 
+// Read and Close both touch the tee reader and its backing buffer, and
+// net/http's transport may Read the request body from its own goroutine while
+// the handler's deferred Close drains it. The mutex serializes the two so the
+// non-thread-safe bytes.Buffer is never accessed concurrently.
 func (r *logReadCloser) Read(p []byte) (n int, err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.closed {
+		return 0, io.EOF
+	}
+
 	return r.reader.Read(p)
 }
 
 func (r *logReadCloser) Close() error {
+	r.mu.Lock()
+
 	if r.closed {
+		r.mu.Unlock()
 		return nil
 	}
 
@@ -147,6 +163,8 @@ func (r *logReadCloser) Close() error {
 	data := r.buf.Bytes()
 	logFn := r.logFn
 	logger := r.logger
+
+	r.mu.Unlock()
 
 	go func() {
 		defer func() {

--- a/snooper/logreadcloser_test.go
+++ b/snooper/logreadcloser_test.go
@@ -1,0 +1,106 @@
+package snooper
+
+import (
+	"io"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+func raceTestSnooper() *Snooper {
+	lg := logrus.New()
+	lg.SetOutput(io.Discard)
+
+	return &Snooper{logger: lg}
+}
+
+// A reader concurrently Read by one goroutine (as net/http's transport does when
+// streaming the request body) and Closed by another (the handler's deferred
+// Close) must not touch its backing buffer concurrently. Run under -race.
+func TestLogReadCloserConcurrentReadClose(t *testing.T) {
+	s := raceTestSnooper()
+
+	for iter := 0; iter < 200; iter++ {
+		pr, pw := io.Pipe()
+
+		go func() {
+			for i := 0; i < 40; i++ {
+				if _, err := pw.Write([]byte("some-body-chunk")); err != nil {
+					return
+				}
+			}
+			_ = pw.Close()
+		}()
+
+		var logged int32
+		rc := s.createTeeLogStream(pr, func(data []byte) {
+			atomic.StoreInt32(&logged, int32(len(data)))
+		})
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+			_, _ = io.Copy(io.Discard, rc) // transport-style reader
+		}()
+
+		time.Sleep(time.Microsecond) // let some reads happen, then close mid-stream
+		_ = rc.Close()
+		_ = rc.Close() // idempotent second close must be safe
+		wg.Wait()
+	}
+}
+
+// Close must be idempotent and the logging callback must fire exactly once.
+func TestLogReadCloserCloseIdempotent(t *testing.T) {
+	s := raceTestSnooper()
+
+	pr, pw := io.Pipe()
+	go func() {
+		_, _ = pw.Write([]byte("hello"))
+		_ = pw.Close()
+	}()
+
+	var calls int32
+	rc := s.createTeeLogStream(pr, func([]byte) {
+		atomic.AddInt32(&calls, 1)
+	})
+
+	_, _ = io.Copy(io.Discard, rc)
+
+	if err := rc.Close(); err != nil {
+		t.Fatalf("first close: %v", err)
+	}
+	if err := rc.Close(); err != nil {
+		t.Fatalf("second close: %v", err)
+	}
+
+	time.Sleep(50 * time.Millisecond) // allow the log goroutine to run
+
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("expected the log callback to fire exactly once, got %d", got)
+	}
+}
+
+// After Close, further Reads must return EOF rather than racing the drain.
+func TestLogReadCloserReadAfterClose(t *testing.T) {
+	s := raceTestSnooper()
+
+	pr, pw := io.Pipe()
+	go func() {
+		_, _ = pw.Write([]byte("data"))
+		_ = pw.Close()
+	}()
+
+	rc := s.createTeeLogStream(pr, func([]byte) {})
+	_ = rc.Close()
+
+	n, err := rc.Read(make([]byte, 8))
+	if n != 0 || err != io.EOF {
+		t.Fatalf("read after close: got n=%d err=%v, want 0, EOF", n, err)
+	}
+}


### PR DESCRIPTION
logReadCloser wraps the proxied request body in an io.TeeReader that writes into a bytes.Buffer for logging. net/http's transport reads the body from its own goroutine to send it upstream, while the handler's deferred Close drains the same tee into the buffer. When the upstream answers before the body is fully sent, Read and Close run at the same time and write the non-thread-safe bytes.Buffer concurrently.

The race detector confirms it: a Read at logging.go Read racing the drain in Close. It fires on ordinary traffic when the upstream returns early, for example a 413 or an auth rejection on a large request body.

This guards Read and Close with a mutex so the tee and its buffer are never accessed concurrently, and returns EOF from Read once closed. Close remains idempotent. The drain in Close only runs after the response is received, so the transport has stopped issuing reads and there is no new blocking behavior.

Tests cover concurrent Read/Close under the race detector, idempotent close, and read after close.