### PR TITLE
Authenticate the control API on the proxy port

### DIFF
--- a/cmd/snooper/main.go
+++ b/cmd/snooper/main.go
@@ -329,7 +329,7 @@ func main() {
 		}
 	}
 
-	err = rpcSnooper.StartServer(cliArgs.bind, cliArgs.port, cliArgs.noapi)
+	err = rpcSnooper.StartServer(cliArgs.bind, cliArgs.port, cliArgs.noapi, cliArgs.apiAuth)
 	if err != nil {
 		logger.Errorf("Failed processing server: %v", err)
 	}

--- a/snooper/apiauth_test.go
+++ b/snooper/apiauth_test.go
@@ -1,0 +1,122 @@
+package snooper
+
+import (
+	"encoding/base64"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+func authTestSnooper(t *testing.T, target string) *Snooper {
+	t.Helper()
+
+	lg := logrus.New()
+	lg.SetOutput(io.Discard)
+
+	s, err := NewSnooper(target, lg, nil, "")
+	if err != nil {
+		t.Fatalf("NewSnooper: %v", err)
+	}
+
+	return s
+}
+
+func basicAuth(user, pass string) string {
+	return "Basic " + base64.StdEncoding.EncodeToString([]byte(user+":"+pass))
+}
+
+// With api-auth configured, the control API on the proxy port must reject
+// unauthenticated requests and accept correctly authenticated ones.
+func TestControlAPIRequiresAuthOnProxyPort(t *testing.T) {
+	s := authTestSnooper(t, "http://127.0.0.1:1")
+	s.configureAPIAuth("admin:secret")
+
+	handler := s.newRootHandler(false)
+
+	// No credentials -> 401.
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/_snooper/status", nil))
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("no credentials: got %d, want 401", rec.Code)
+	}
+
+	// Wrong credentials -> 401.
+	rec = httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/_snooper/status", nil)
+	req.Header.Set("Authorization", basicAuth("admin", "wrong"))
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("wrong credentials: got %d, want 401", rec.Code)
+	}
+
+	// Correct credentials -> reaches the handler (not 401).
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/_snooper/status", nil)
+	req.Header.Set("Authorization", basicAuth("admin", "secret"))
+	handler.ServeHTTP(rec, req)
+	if rec.Code == http.StatusUnauthorized {
+		t.Fatalf("correct credentials were rejected: got 401")
+	}
+}
+
+// The state-changing stop endpoint must not be reachable without credentials.
+func TestControlStopRequiresAuth(t *testing.T) {
+	s := authTestSnooper(t, "http://127.0.0.1:1")
+	s.configureAPIAuth("admin:secret")
+	s.flowEnabled = true
+
+	handler := s.newRootHandler(false)
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/_snooper/stop", nil))
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated stop: got %d, want 401", rec.Code)
+	}
+	if !s.flowEnabled {
+		t.Fatalf("unauthenticated stop disabled the proxy flow")
+	}
+}
+
+// Proxied traffic must never be gated by the control-API credentials.
+func TestProxyTrafficNotAuthenticated(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.Copy(io.Discard, r.Body)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"ok":true}`))
+	}))
+	defer upstream.Close()
+
+	s := authTestSnooper(t, upstream.URL)
+	s.configureAPIAuth("admin:secret")
+
+	handler := s.newRootHandler(false)
+
+	// A normal proxied request with no credentials must succeed.
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/eth/v1/x", nil))
+
+	if rec.Code == http.StatusUnauthorized {
+		t.Fatalf("proxied traffic was blocked by control-API auth (401)")
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("proxied request: got %d, want 200", rec.Code)
+	}
+}
+
+// Without api-auth configured the control API stays open (unchanged behavior).
+func TestControlAPIOpenWhenNoAuthConfigured(t *testing.T) {
+	s := authTestSnooper(t, "http://127.0.0.1:1")
+
+	handler := s.newRootHandler(false)
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/_snooper/status", nil))
+
+	if rec.Code == http.StatusUnauthorized {
+		t.Fatalf("status endpoint returned 401 with no auth configured")
+	}
+}

--- a/snooper/snooper.go
+++ b/snooper/snooper.go
@@ -139,7 +139,9 @@ func (s *Snooper) Shutdown() {
 	}
 }
 
-func (s *Snooper) StartServer(host string, port int, noAPI bool) error {
+func (s *Snooper) StartServer(host string, port int, noAPI bool, authConfig string) error {
+	s.configureAPIAuth(authConfig)
+
 	// Start Xatu service if enabled
 	// Note: We use context.Background() because the xatu service workers
 	// need a long-lived context that won't be cancelled until shutdown.
@@ -165,11 +167,36 @@ func (s *Snooper) StartServer(host string, port int, noAPI bool) error {
 		}
 	}
 
+	srv := &http.Server{
+		Addr:              fmt.Sprintf("%v:%v", host, port),
+		Handler:           s.newRootHandler(noAPI),
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+
+	s.logger.Infof("listening on: %v", srv.Addr)
+
+	if !noAPI && len(s.apiAuth) > 0 {
+		s.logger.Infof("control API authentication enabled for %d users", len(s.apiAuth))
+	}
+
+	return srv.ListenAndServe()
+}
+
+// newRootHandler builds the proxy-port handler: the control API under
+// /_snooper/ (guarded by Basic auth when api-auth is configured) plus the proxy
+// itself. Auth is scoped to the control subrouter so proxied traffic is never
+// gated.
+func (s *Snooper) newRootHandler(noAPI bool) http.Handler {
 	router := mux.NewRouter()
 
 	if !noAPI {
 		s.api = newAPI(s)
 		apiRouter := router.PathPrefix("/_snooper/").Subrouter()
+
+		if len(s.apiAuth) > 0 {
+			apiRouter.Use(s.requireAPIAuth)
+		}
+
 		s.api.initRouter(apiRouter)
 	}
 
@@ -179,29 +206,11 @@ func (s *Snooper) StartServer(host string, port int, noAPI bool) error {
 	n.Use(negroni.NewRecovery())
 	n.UseHandler(router)
 
-	srv := &http.Server{
-		Addr:              fmt.Sprintf("%v:%v", host, port),
-		Handler:           n,
-		ReadHeaderTimeout: 10 * time.Second,
-	}
-
-	s.logger.Infof("listening on: %v", srv.Addr)
-
-	return srv.ListenAndServe()
+	return n
 }
 
 func (s *Snooper) StartAPIServer(host string, port int, authConfig string) error {
-	// Parse authentication configuration
-	if authConfig != "" {
-		s.apiAuth = make(map[string]string)
-
-		for _, cred := range strings.Split(authConfig, ",") {
-			parts := strings.SplitN(cred, ":", 2)
-			if len(parts) == 2 {
-				s.apiAuth[parts[0]] = parts[1]
-			}
-		}
-	}
+	s.configureAPIAuth(authConfig)
 
 	router := mux.NewRouter()
 
@@ -288,40 +297,69 @@ func (s *Snooper) collectMetrics(req *http.Request, respCtx *types.ResponseConte
 	metrics.PrometheusMetricsRegister(metricsEntry)
 }
 
-func (s *Snooper) authMiddleware(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
-	// Extract basic auth credentials
-	auth := r.Header.Get("Authorization")
-	if auth == "" {
-		s.sendUnauthorized(w)
+// configureAPIAuth parses the api-auth config (user:pass,user2:pass2,...) into
+// the credential map. Safe to call from more than one start path.
+func (s *Snooper) configureAPIAuth(authConfig string) {
+	if authConfig == "" {
 		return
 	}
 
+	s.apiAuth = make(map[string]string)
+
+	for _, cred := range strings.Split(authConfig, ",") {
+		parts := strings.SplitN(cred, ":", 2)
+		if len(parts) == 2 {
+			s.apiAuth[parts[0]] = parts[1]
+		}
+	}
+}
+
+// authorized reports whether the request carries valid Basic credentials.
+func (s *Snooper) authorized(r *http.Request) bool {
 	const prefix = "Basic "
+
+	auth := r.Header.Get("Authorization")
 	if !strings.HasPrefix(auth, prefix) {
-		s.sendUnauthorized(w)
-		return
+		return false
 	}
 
 	decoded, err := base64.StdEncoding.DecodeString(auth[len(prefix):])
 	if err != nil {
-		s.sendUnauthorized(w)
-		return
+		return false
 	}
 
 	credentials := string(decoded)
 
 	colonIndex := strings.IndexByte(credentials, ':')
 	if colonIndex < 0 {
-		s.sendUnauthorized(w)
-		return
+		return false
 	}
 
 	username := credentials[:colonIndex]
 	password := credentials[colonIndex+1:]
 
-	// Check credentials
 	expectedPassword, ok := s.apiAuth[username]
-	if !ok || subtle.ConstantTimeCompare([]byte(password), []byte(expectedPassword)) != 1 {
+
+	return ok && subtle.ConstantTimeCompare([]byte(password), []byte(expectedPassword)) == 1
+}
+
+// requireAPIAuth is mux middleware that enforces Basic auth on the routes it
+// wraps. It guards the control API mounted on the proxy port.
+func (s *Snooper) requireAPIAuth(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !s.authorized(r) {
+			s.sendUnauthorized(w)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+// authMiddleware is the negroni form of the same check, used by the separate
+// API server.
+func (s *Snooper) authMiddleware(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	if !s.authorized(r) {
 		s.sendUnauthorized(w)
 		return
 	}


### PR DESCRIPTION
The /_snooper control API (start, stop, block, unblock, and the module control WebSocket) is mounted on the main proxy port with no authentication. api-auth is only wired into the separate API server started by StartAPIServer, so an operator who sets credentials still exposes the full control surface unauthenticated on the proxy port, which is the port the proxied client connects to.

The impact is direct: an unauthenticated POST to /_snooper/stop sets flowEnabled to false, after which every proxied request returns 503, severing the link the proxy sits on. The documented setup with both api-auth and a separate api-port is affected, since the control API is still mounted unauthenticated on the proxy port unless no-api is set.

This parses api-auth in StartServer as well and applies the same Basic auth to the /_snooper routes there, scoped to that subrouter so proxied traffic is never authenticated. The credential check and config parsing are factored into shared helpers used by both listeners. When no credentials are configured the control API stays open, so existing setups without api-auth are unchanged.

Tests cover auth required, wrong and correct credentials, unauthenticated stop leaving the flow enabled, unauthenticated proxy traffic passing through, and the open default when no credentials are set.