### PR TITLE
Fix data races on ProxyCallContext cancelled and stream reader

### DIFF
--- a/snooper/proxycall.go
+++ b/snooper/proxycall.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"time"
 )
 
@@ -16,7 +17,7 @@ type ProxyCallContext struct {
 	callIndex    uint64
 	context      context.Context
 	cancelFn     context.CancelFunc
-	cancelled    bool
+	cancelled    atomic.Bool
 	deadline     time.Time
 	updateChan   chan time.Duration
 	reqSentChan  chan struct{}
@@ -56,12 +57,12 @@ ctxLoop:
 			break ctxLoop
 		case <-time.After(timeout):
 			callContext.cancelFn()
-			callContext.cancelled = true
+			callContext.cancelled.Store(true)
 			time.Sleep(10 * time.Millisecond)
 		}
 	}
 
-	callContext.cancelled = true
+	callContext.cancelled.Store(true)
 
 	if callContext.streamReader != nil {
 		callContext.streamReader.Close()
@@ -178,7 +179,7 @@ func (s *Snooper) processProxyCall(w http.ResponseWriter, r *http.Request) error
 		return fmt.Errorf("proxy request error: %w", err)
 	}
 
-	if callContext.cancelled {
+	if callContext.cancelled.Load() {
 		resp.Body.Close()
 		return fmt.Errorf("proxy context cancelled")
 	}
@@ -281,7 +282,7 @@ func (s *Snooper) processEventStreamResponse(callContext *ProxyCallContext, r *h
 			f.Flush()
 		}
 
-		if callContext.cancelled {
+		if callContext.cancelled.Load() {
 			return written, nil
 		}
 

--- a/snooper/proxycall.go
+++ b/snooper/proxycall.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 )
@@ -21,6 +22,7 @@ type ProxyCallContext struct {
 	deadline     time.Time
 	updateChan   chan time.Duration
 	reqSentChan  chan struct{}
+	streamMutex  sync.Mutex
 	streamReader io.ReadCloser
 	data         map[string]interface{}
 	callDuration time.Duration
@@ -64,8 +66,27 @@ ctxLoop:
 
 	callContext.cancelled.Store(true)
 
-	if callContext.streamReader != nil {
-		callContext.streamReader.Close()
+	callContext.closeStreamReader()
+}
+
+// setStreamReader records the upstream response body so the watchdog can close
+// it on cancellation. The write races the watchdog's read, so it is guarded.
+func (callContext *ProxyCallContext) setStreamReader(r io.ReadCloser) {
+	callContext.streamMutex.Lock()
+	callContext.streamReader = r
+	callContext.streamMutex.Unlock()
+}
+
+// closeStreamReader closes the recorded upstream body if one has been set. The
+// mutex serializes it with setStreamReader; the close itself runs outside the
+// lock so it never blocks a concurrent setter.
+func (callContext *ProxyCallContext) closeStreamReader() {
+	callContext.streamMutex.Lock()
+	r := callContext.streamReader
+	callContext.streamMutex.Unlock()
+
+	if r != nil {
+		r.Close()
 	}
 }
 
@@ -184,7 +205,7 @@ func (s *Snooper) processProxyCall(w http.ResponseWriter, r *http.Request) error
 		return fmt.Errorf("proxy context cancelled")
 	}
 
-	callContext.streamReader = resp.Body
+	callContext.setStreamReader(resp.Body)
 
 	respContentType := resp.Header.Get("Content-Type")
 	isEventStream := respContentType == "text/event-stream" || strings.HasPrefix(r.URL.EscapedPath(), "/eth/v1/events")

--- a/snooper/proxycall_race_test.go
+++ b/snooper/proxycall_race_test.go
@@ -1,0 +1,42 @@
+package snooper
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+// The watchdog goroutine writes ProxyCallContext.cancelled on timeout while the
+// request and event-stream goroutines read it. This exercises that concurrent
+// access; with an atomic flag it is race-free. Run under -race.
+func TestCancelledFlagRaceFree(t *testing.T) {
+	s := &Snooper{}
+
+	// Short timeout so the watchdog fires and writes cancelled during the read
+	// window below.
+	cc := s.newProxyCallContext(context.Background(), 5*time.Millisecond)
+	defer cc.cancelFn()
+
+	var wg sync.WaitGroup
+
+	deadline := time.Now().Add(60 * time.Millisecond)
+
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			for time.Now().Before(deadline) {
+				_ = cc.cancelled.Load()
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	if !cc.cancelled.Load() {
+		t.Fatal("expected cancelled to be set after the timeout fired")
+	}
+}

--- a/snooper/proxycall_race_test.go
+++ b/snooper/proxycall_race_test.go
@@ -2,6 +2,8 @@ package snooper
 
 import (
 	"context"
+	"io"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -38,5 +40,29 @@ func TestCancelledFlagRaceFree(t *testing.T) {
 
 	if !cc.cancelled.Load() {
 		t.Fatal("expected cancelled to be set after the timeout fired")
+	}
+}
+
+// The watchdog closes ProxyCallContext.streamReader on cancellation while the
+// request goroutine sets it once the upstream responds. This exercises that
+// set-versus-close interleaving; the mutex keeps it race-free. Run under -race.
+func TestStreamReaderRaceFree(t *testing.T) {
+	for iter := 0; iter < 500; iter++ {
+		cc := &ProxyCallContext{}
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		go func() {
+			defer wg.Done()
+			cc.setStreamReader(io.NopCloser(strings.NewReader("body")))
+		}()
+
+		go func() {
+			defer wg.Done()
+			cc.closeStreamReader()
+		}()
+
+		wg.Wait()
 	}
 }


### PR DESCRIPTION
ProxyCallContext has two fields shared between the per-call watchdog goroutine and the request and event-stream goroutines with no synchronization. The race detector flags both.

cancelled is a plain bool written by the watchdog when the deadline fires and read by the request and event-stream goroutines to decide whether to abort the call. It is changed to atomic.Bool with Store and Load at the write and read sites.

streamReader is an interface written by the request goroutine once the upstream responds and read plus closed by the watchdog on cancellation. A torn interface read can pass the nil check and then dispatch on a nil value, crashing a goroutine that has no recover, so this one can take the process down, not just trip the detector. The write and the close now go through helpers guarded by a mutex, with the close performed outside the lock so it never blocks a setter.

Each field has a test that exercises the concurrent access under the race detector.