### PR TITLE
Cap response buffer pre-allocation size

### DIFF
--- a/snooper/logging.go
+++ b/snooper/logging.go
@@ -101,12 +101,25 @@ func (s *Snooper) createTeeLogStream(stream io.ReadCloser, logfn func(data []byt
 	return s.createTeeLogStreamWithSizeHint(stream, 0, logfn)
 }
 
+// maxPreallocSize bounds how large a buffer createTeeLogStreamWithSizeHint will
+// pre-allocate from a caller-supplied size hint. The hint usually comes from a
+// response Content-Length header, which is not trustworthy: a hostile or buggy
+// upstream can declare an arbitrary value and force a matching allocation
+// before a single body byte has arrived. Capping it still gives real payloads
+// the throughput benefit of pre-allocation, without letting the declared size
+// alone drive memory use.
+const maxPreallocSize = 64 << 20 // 64 MiB
+
 // createTeeLogStreamWithSizeHint creates a tee log stream with an optional size hint for buffer pre-allocation.
-// When sizeHint > 0, the buffer is pre-allocated to avoid reallocations during streaming.
+// When sizeHint > 0, the buffer is pre-allocated (up to maxPreallocSize) to avoid reallocations during streaming.
 // This provides ~2x throughput improvement for large payloads.
 func (s *Snooper) createTeeLogStreamWithSizeHint(stream io.ReadCloser, sizeHint int64, logfn func(data []byte)) io.ReadCloser {
 	var buf *bytes.Buffer
 	if sizeHint > 0 {
+		if sizeHint > maxPreallocSize {
+			sizeHint = maxPreallocSize
+		}
+
 		buf = bytes.NewBuffer(make([]byte, 0, sizeHint))
 	} else {
 		buf = new(bytes.Buffer)

--- a/snooper/prealloc_test.go
+++ b/snooper/prealloc_test.go
@@ -1,0 +1,87 @@
+package snooper
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+func quietTestSnooper(t *testing.T, target string) *Snooper {
+	lg := logrus.New()
+	lg.SetOutput(io.Discard)
+	lg.SetLevel(logrus.InfoLevel)
+
+	s, err := NewSnooper(target, lg, nil, "")
+	if err != nil {
+		t.Fatalf("NewSnooper: %v", err)
+	}
+
+	return s
+}
+
+func TestCreateTeeLogStreamWithSizeHint_ClampsOversizedHint(t *testing.T) {
+	s := quietTestSnooper(t, "http://127.0.0.1:1")
+
+	stream := s.createTeeLogStreamWithSizeHint(io.NopCloser(bytes.NewReader(nil)), 512<<20, func([]byte) {})
+	defer stream.Close()
+
+	rc, ok := stream.(*logReadCloser)
+	if !ok {
+		t.Fatalf("expected *logReadCloser, got %T", stream)
+	}
+
+	if got := rc.buf.Cap(); got > maxPreallocSize {
+		t.Fatalf("buffer pre-allocated %d bytes for a 512 MiB hint, want at most %d", got, maxPreallocSize)
+	}
+}
+
+func TestCreateTeeLogStreamWithSizeHint_KeepsSmallHint(t *testing.T) {
+	s := quietTestSnooper(t, "http://127.0.0.1:1")
+
+	const hint = 4096
+
+	stream := s.createTeeLogStreamWithSizeHint(io.NopCloser(bytes.NewReader(nil)), hint, func([]byte) {})
+	defer stream.Close()
+
+	rc, ok := stream.(*logReadCloser)
+	if !ok {
+		t.Fatalf("expected *logReadCloser, got %T", stream)
+	}
+
+	if got := rc.buf.Cap(); got < hint {
+		t.Fatalf("buffer pre-allocated only %d bytes for a %d byte hint, expected at least the hint honored", got, hint)
+	}
+}
+
+func TestResponseProcessing_HostileContentLengthStaysBounded(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Length", "536870912") // 512 MiB, hostile or buggy
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer upstream.Close()
+
+	s := quietTestSnooper(t, upstream.URL)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+
+	var m0, m1 runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&m0)
+
+	s.ServeHTTP(rec, req)
+
+	runtime.ReadMemStats(&m1)
+	delta := m1.TotalAlloc - m0.TotalAlloc
+
+	if delta > 2*maxPreallocSize {
+		t.Fatalf("allocation delta %d bytes exceeds the pre-allocation cap by more than a safety margin", delta)
+	}
+}


### PR DESCRIPTION
createTeeLogStreamWithSizeHint pre-allocates a buffer sized directly off a caller-supplied hint. For responses, that hint is the upstream Content-Length header, which is not trustworthy: a hostile or buggy upstream can declare an arbitrary length and force a matching allocation before a single body byte has arrived.

A response declaring a 512 MiB Content-Length forces a 512 MiB allocation immediately, regardless of how many bytes the upstream actually sends. Concurrent responses each pay this cost independently, with no shared cap.

This clamps the hint to 64 MiB before pre-allocating. Real payloads still get the throughput benefit of pre-allocation up to that size; anything larger just grows the buffer normally instead of being pre-allocated in full.

Tests cover the clamp on an oversized hint, that a normal small hint is still honored, and an end to end case through the real proxy with a hostile Content-Length header.