### PR TITLE
Stop a long SSE line from killing the event stream

### DIFF
--- a/snooper/proxycall.go
+++ b/snooper/proxycall.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -245,15 +246,21 @@ func (s *Snooper) processProxyCall(w http.ResponseWriter, r *http.Request) error
 	return nil
 }
 
+// maxSSELineSize bounds how large a single SSE line may grow when it does not
+// fit in one bufio.Reader chunk. Without this, a line longer than the reader's
+// buffer would fall through to readSSELine's own safety cap; this is the value
+// that cap uses, chosen generously above any realistic beacon event.
+const maxSSELineSize = 4 << 20 // 4 MiB
+
 func (s *Snooper) processEventStreamResponse(callContext *ProxyCallContext, r *http.Request, w http.ResponseWriter, rsp *http.Response) (int64, error) {
-	rd := bufio.NewReader(rsp.Body)
+	rd := bufio.NewReaderSize(rsp.Body, 64*1024)
 	written := int64(0)
 
 	for {
 		lineBuf := []byte{}
 
 		for {
-			evt, err := rd.ReadSlice('\n')
+			evt, err := readSSELine(rd, maxSSELineSize)
 			if err != nil {
 				return written, err
 			}
@@ -286,6 +293,51 @@ func (s *Snooper) processEventStreamResponse(callContext *ProxyCallContext, r *h
 		}
 
 		callContext.updateChan <- s.CallTimeout
+	}
+}
+
+// readSSELine reads one line, through and including the trailing '\n', from
+// rd. bufio.Reader.ReadSlice fails with ErrBufferFull when a line does not fit
+// in the reader's internal buffer in one pass; instead of treating that as a
+// terminal error and killing the stream, this accumulates chunks across the
+// boundary and keeps going until it sees a real line ending, a real read
+// error, or the assembled line exceeds maxLen. maxLen guards against an
+// unbounded line from a hostile or broken upstream.
+func readSSELine(rd *bufio.Reader, maxLen int) ([]byte, error) {
+	var line []byte
+
+	for {
+		chunk, err := rd.ReadSlice('\n')
+
+		if errors.Is(err, bufio.ErrBufferFull) {
+			line = append(line, chunk...)
+
+			if len(line) > maxLen {
+				return nil, fmt.Errorf("SSE line exceeds %d byte limit", maxLen)
+			}
+
+			continue
+		}
+
+		if err != nil {
+			return nil, err
+		}
+
+		if line == nil {
+			if len(chunk) > maxLen {
+				return nil, fmt.Errorf("SSE line exceeds %d byte limit", maxLen)
+			}
+
+			return chunk, nil
+		}
+
+		line = append(line, chunk...)
+
+		if len(line) > maxLen {
+			return nil, fmt.Errorf("SSE line exceeds %d byte limit", maxLen)
+		}
+
+		return line, nil
 	}
 }
 

--- a/snooper/sse_test.go
+++ b/snooper/sse_test.go
@@ -1,0 +1,184 @@
+package snooper
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+func quietTestSnooper(t *testing.T, target string) *Snooper {
+	lg := logrus.New()
+	lg.SetOutput(io.Discard)
+	lg.SetLevel(logrus.InfoLevel)
+
+	s, err := NewSnooper(target, lg, nil, "")
+	if err != nil {
+		t.Fatalf("NewSnooper: %v", err)
+	}
+
+	return s
+}
+
+func TestReadSSELine_SurvivesLineLongerThanBufioBuffer(t *testing.T) {
+	long := strings.Repeat("A", 5000) + "\n" // longer than a small reader buffer
+	rd := bufio.NewReaderSize(strings.NewReader(long), 512)
+
+	line, err := readSSELine(rd, 1<<20)
+	if err != nil {
+		t.Fatalf("readSSELine: %v", err)
+	}
+
+	if string(line) != long {
+		t.Fatalf("got %d bytes, want %d", len(line), len(long))
+	}
+}
+
+func TestReadSSELine_ShortLineUnaffected(t *testing.T) {
+	rd := bufio.NewReaderSize(strings.NewReader("data: ok\n"), 4096)
+
+	line, err := readSSELine(rd, 1<<20)
+	if err != nil {
+		t.Fatalf("readSSELine: %v", err)
+	}
+
+	if string(line) != "data: ok\n" {
+		t.Fatalf("got %q", string(line))
+	}
+}
+
+func TestReadSSELine_RejectsLineOverHardCap(t *testing.T) {
+	huge := strings.Repeat("A", 200) + "\n"
+	rd := bufio.NewReaderSize(strings.NewReader(huge), 64)
+
+	_, err := readSSELine(rd, 100)
+	if err == nil {
+		t.Fatal("expected an error once the line exceeds the hard cap, got nil")
+	}
+}
+
+func TestReadSSELine_PropagatesRealReadError(t *testing.T) {
+	rd := bufio.NewReaderSize(strings.NewReader("no newline here"), 4096)
+
+	_, err := readSSELine(rd, 1<<20)
+	if err == nil {
+		t.Fatal("expected an error for a stream that ends without a newline")
+	}
+}
+
+// flushRecorder makes httptest.ResponseRecorder satisfy http.Flusher, which
+// the event-stream response path requires.
+type flushRecorder struct {
+	*httptest.ResponseRecorder
+}
+
+func (f *flushRecorder) Flush() { f.ResponseRecorder.Flush() }
+
+func TestEventStream_LongLineNoLongerKillsTheStream(t *testing.T) {
+	const firstMarker = "first-event"
+	const thirdMarker = "third-event"
+
+	long := strings.Repeat("A", 5000) // one line over the old 4096-byte default
+
+	var body bytes.Buffer
+	body.WriteString("data: {\"tag\":\"" + firstMarker + "\"}\n\n")
+	body.WriteString("data: " + long + "\n\n")
+	body.WriteString("data: {\"tag\":\"" + thirdMarker + "\"}\n\n")
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+
+		b := body.Bytes()
+		const chunk = 512
+
+		for i := 0; i < len(b); i += chunk {
+			end := i + chunk
+			if end > len(b) {
+				end = len(b)
+			}
+
+			_, _ = w.Write(b[i:end])
+
+			if f, ok := w.(http.Flusher); ok {
+				f.Flush()
+			}
+		}
+	}))
+	defer upstream.Close()
+
+	s := quietTestSnooper(t, upstream.URL)
+
+	req := httptest.NewRequest(http.MethodGet, "/eth/v1/events?topics=head", nil)
+	rec := &flushRecorder{httptest.NewRecorder()}
+
+	done := make(chan struct{})
+
+	go func() {
+		s.ServeHTTP(rec, req)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("ServeHTTP never returned")
+	}
+
+	got := rec.Body.String()
+
+	if !strings.Contains(got, firstMarker) {
+		t.Fatalf("expected the event before the long line to reach the client, got %q", got)
+	}
+
+	if !strings.Contains(got, thirdMarker) {
+		t.Fatalf("expected the event after the long line to also reach the client, got %q", got)
+	}
+}
+
+func TestEventStream_LineOverHardCapStillTerminatesStream(t *testing.T) {
+	huge := strings.Repeat("A", maxSSELineSize+1)
+
+	var body bytes.Buffer
+	body.WriteString("data: " + huge + "\n\n")
+	body.WriteString("data: {\"tag\":\"unreachable\"}\n\n")
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body.Bytes())
+
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+	}))
+	defer upstream.Close()
+
+	s := quietTestSnooper(t, upstream.URL)
+
+	req := httptest.NewRequest(http.MethodGet, "/eth/v1/events?topics=head", nil)
+	rec := &flushRecorder{httptest.NewRecorder()}
+
+	done := make(chan struct{})
+
+	go func() {
+		s.ServeHTTP(rec, req)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("ServeHTTP never returned")
+	}
+
+	if strings.Contains(rec.Body.String(), "unreachable") {
+		t.Fatal("a line over the hard cap should still terminate the stream")
+	}
+}


### PR DESCRIPTION
processEventStreamResponse reads event lines with bufio.Reader's plain ReadSlice, which fails with ErrBufferFull the moment a single line does not fit in the reader's fixed internal buffer (4096 bytes by default). Any SSE line over that size terminates the entire /eth/v1/events proxy connection, including every event after it, with no error surfaced to the caller beyond a closed connection.

This can happen with a real, non-malicious beacon node whenever a single event payload is larger than 4 KiB, which is plausible for events carrying a full block or checkpoint.

This adds a small wrapper that keeps reading across that buffer boundary and reassembles the full line, bounded by a generous 4 MiB hard cap so a genuinely unbounded line from a broken or hostile upstream still ends the stream instead of growing forever. It also raises the reader's own buffer to 64KB so the common case no longer needs reassembly at all.

Tests cover a line that spans multiple buffer fills, a normal short line, a line at and over the hard cap, propagation of a real read error, and an end to end case proving events after the long line still reach the client.