### PR TITLE
Reject malformed api-auth entries instead of dropping them

### DIFF
--- a/snooper/apiauth_test.go
+++ b/snooper/apiauth_test.go
@@ -1,0 +1,122 @@
+package snooper
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+func TestParseAPIAuth_ValidEntries(t *testing.T) {
+	auth, err := parseAPIAuth("admin:secret,operator:pass")
+	if err != nil {
+		t.Fatalf("parseAPIAuth: %v", err)
+	}
+
+	if auth["admin"] != "secret" || auth["operator"] != "pass" {
+		t.Fatalf("unexpected credential map: %v", auth)
+	}
+}
+
+func TestParseAPIAuth_MissingColonIsRejected(t *testing.T) {
+	if _, err := parseAPIAuth("adminsecret"); err == nil {
+		t.Fatal("expected an error for an entry missing the colon separator, got nil")
+	}
+}
+
+func TestParseAPIAuth_OneBadEntryRejectsTheWholeConfig(t *testing.T) {
+	// One well-formed entry alongside one malformed entry must not silently
+	// keep only the good one: the whole config is rejected so the operator
+	// finds out at startup, not by testing every user later.
+	if _, err := parseAPIAuth("admin:secret,operatorpass"); err == nil {
+		t.Fatal("expected an error when any entry in the list is malformed, got nil")
+	}
+}
+
+func TestParseAPIAuth_EmptyUsernameIsRejected(t *testing.T) {
+	if _, err := parseAPIAuth(":secret"); err == nil {
+		t.Fatal("expected an error for an entry with an empty username, got nil")
+	}
+}
+
+func quietTestSnooperAuth(t *testing.T, target string) *Snooper {
+	lg := logrus.New()
+	lg.SetOutput(io.Discard)
+	lg.SetLevel(logrus.InfoLevel)
+
+	s, err := NewSnooper(target, lg, nil, "")
+	if err != nil {
+		t.Fatalf("NewSnooper: %v", err)
+	}
+
+	return s
+}
+
+func freePortAuth(t *testing.T) int {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed reserving a free port: %v", err)
+	}
+
+	port := l.Addr().(*net.TCPAddr).Port
+	_ = l.Close()
+
+	return port
+}
+
+func waitForServerAuth(t *testing.T, port int) {
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), 100*time.Millisecond)
+		if err == nil {
+			_ = conn.Close()
+			return
+		}
+
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	t.Fatalf("API server on port %d never came up", port)
+}
+
+func TestStartAPIServer_MalformedAuthConfigFailsToStart(t *testing.T) {
+	s := quietTestSnooperAuth(t, "http://127.0.0.1:1")
+	port := freePortAuth(t)
+
+	err := s.StartAPIServer("127.0.0.1", port, "adminsecret")
+	if err == nil {
+		t.Fatal("expected StartAPIServer to return an error for a malformed api-auth config")
+	}
+
+	// The server must never come up unauthenticated because of a typo.
+	conn, dialErr := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), 200*time.Millisecond)
+	if dialErr == nil {
+		conn.Close()
+		t.Fatal("API server accepted connections despite a rejected auth config")
+	}
+}
+
+func TestStartAPIServer_ValidAuthConfigStillEnforced(t *testing.T) {
+	s := quietTestSnooperAuth(t, "http://127.0.0.1:1")
+	port := freePortAuth(t)
+
+	if err := s.StartAPIServer("127.0.0.1", port, "admin:secret"); err != nil {
+		t.Fatalf("StartAPIServer: %v", err)
+	}
+
+	waitForServerAuth(t, port)
+
+	resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/_snooper/status", port))
+	if err != nil {
+		t.Fatalf("GET /_snooper/status: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for an unauthenticated request against a valid auth config, got %d", resp.StatusCode)
+	}
+}

--- a/snooper/snooper.go
+++ b/snooper/snooper.go
@@ -191,16 +191,13 @@ func (s *Snooper) StartServer(host string, port int, noAPI bool) error {
 }
 
 func (s *Snooper) StartAPIServer(host string, port int, authConfig string) error {
-	// Parse authentication configuration
 	if authConfig != "" {
-		s.apiAuth = make(map[string]string)
-
-		for _, cred := range strings.Split(authConfig, ",") {
-			parts := strings.SplitN(cred, ":", 2)
-			if len(parts) == 2 {
-				s.apiAuth[parts[0]] = parts[1]
-			}
+		apiAuth, err := parseAPIAuth(authConfig)
+		if err != nil {
+			return fmt.Errorf("invalid api-auth: %w", err)
 		}
+
+		s.apiAuth = apiAuth
 	}
 
 	router := mux.NewRouter()
@@ -239,6 +236,25 @@ func (s *Snooper) StartAPIServer(host string, port int, authConfig string) error
 	}()
 
 	return nil
+}
+
+// parseAPIAuth parses the api-auth config (user:pass,user2:pass2,...) into a
+// credential map. Every entry must contain a colon; a malformed entry returns
+// an error instead of being dropped, so a typo cannot silently leave the
+// control API unauthenticated while the operator believes it is protected.
+func parseAPIAuth(authConfig string) (map[string]string, error) {
+	auth := make(map[string]string)
+
+	for _, cred := range strings.Split(authConfig, ",") {
+		parts := strings.SplitN(cred, ":", 2)
+		if len(parts) != 2 || parts[0] == "" {
+			return nil, fmt.Errorf("entry %q must be in the form user:pass", cred)
+		}
+
+		auth[parts[0]] = parts[1]
+	}
+
+	return auth, nil
 }
 
 func (s *Snooper) StartMetricsServer(host string, port int) error {


### PR DESCRIPTION
The api-auth config is parsed by splitting on commas and colons, silently skipping any entry that has no colon. If every entry happens to be malformed, the credential map stays empty, and the middleware that gates the API server only attaches when that map is non-empty. A single typo, like a missing colon or a wrong separator, leaves the control API completely unauthenticated with no error or warning, even though the operator explicitly configured credentials.

This moves parsing into its own function and returns an error on the first malformed entry instead of skipping it. StartAPIServer now fails to start rather than silently serving without auth.

Tests cover valid entries, a fully malformed entry, a mix of one good and one bad entry, an empty username, and that the API server refuses to come up at all on a rejected config while a valid config still enforces auth as before.